### PR TITLE
Add learning project xblock to pip requirements

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -365,3 +365,10 @@ urlpatterns +=[
     path ('api/course_unit_time/<str:block_id>', get_time_course_unit , name='get_time_course_unit'),
     path('api/set_course_unit_time',set_course_time_unit, name='set_course_time_unit' )
 ]
+
+# assignmentxblock-xblock js translation
+from django.views.i18n import JavaScriptCatalog
+
+urlpatterns += [
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='assignmentxblock-xblock'),
+]

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -1073,3 +1073,10 @@ urlpatterns +=[
     path ('api/funix_portal/user/create_user', CreateUserAPIView.as_view() , name='funix_portal_create_user'),
     path ('api/funix_portal/project/grade_project', GradeLearningProjectXblockAPIView.as_view() , name='funix_portal_grade_learning_project'),
 ]
+
+# assignmentxblock-xblock js translation
+from django.views.i18n import JavaScriptCatalog
+
+urlpatterns += [
+    path('jsi18n/', JavaScriptCatalog.as_view(), name='assignmentxblock-xblock'),
+]

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1217,3 +1217,5 @@ openpyxl==3.1.2
 # xblock lab
 labxblock-xblock==0.2
 
+# learningprojectxblock
+assignmentxblock-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1715,3 +1715,6 @@ zipp==3.9.0
 
 openpyxl==3.1.2
 labxblock-xblock==0.2
+
+# learningprojectxblock
+assignmentxblock-xblock


### PR DESCRIPTION
Before: 
- project xblock is only installed by setting its git repo in tutor config.yml so not available in devstack.

After: 
- add project xblock to pip packge so it will be installed both in devstack and tutor. 