### PR TITLE
feature (learningprojectxblock): check if xblock has score to grade

### DIFF
--- a/lms/djangoapps/funix_portal_api/views.py
+++ b/lms/djangoapps/funix_portal_api/views.py
@@ -349,9 +349,10 @@ class GradeLearningProjectXblockAPIView(APIView):
                             components = unit.get_children()
                             for component in components:
                                 if type(component).__name__ == 'AssignmentXBlockWithMixins':
-                                    found_learningprojectxblock = True
-                                    usage_id = str(component.scope_ids.usage_id)
-                                    break
+                                    if (component.has_score):
+                                        found_learningprojectxblock = True
+                                        usage_id = str(component.scope_ids.usage_id)
+                                        break
 
         except Exception as e:
             logging.error(str(e))


### PR DESCRIPTION
### Description
According to the new learning project design, a section needs to have two leanring project xblocks. Just one should have "has_score" attribute >> added checking if a leanringprojectxblock has "has_score" attribute to grade. 