### PR TITLE
fix: redirect to /courses when clicked on logo, adjust courses' cards…

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -35,25 +35,28 @@
     <section class="find-courses">
       <section class="courses-container">
         % if course_discovery_enabled:
-        <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
-          <div id="discovery-message" class="search-status-label"></div>
-          <form class="wrapper-search-input">
-            <label for="discovery-input" class="sr">${_('Search for a course')}</label>
-            <input id="discovery-input" class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
-            <button type="submit" class="button postfix discovery-submit" title="${_('Search')}">
-              <span class="icon fa fa-search" aria-hidden="true"></span>
-              <div aria-live="polite" aria-relevant="all">
-                <div id="loading-indicator" class="loading-spinner hidden">
-                  <span class="icon fa fa-spinner fa-spin" aria-hidden="true"></span>
-                  <span class="sr">${_('Loading')}</span>
-                </div>
-              </div>
-            </button>
-          </form>
-        </div>
+        <!--
 
-        <div id="filter-bar" class="filters hide-phone is-collapsed">
-        </div>
+          <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
+            <div id="discovery-message" class="search-status-label"></div>
+            <form class="wrapper-search-input">
+              <label for="discovery-input" class="sr">${_('Search for a course')}</label>
+              <input id="discovery-input" class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
+              <button type="submit" class="button postfix discovery-submit" title="${_('Search')}">
+                <span class="icon fa fa-search" aria-hidden="true"></span>
+                <div aria-live="polite" aria-relevant="all">
+                  <div id="loading-indicator" class="loading-spinner hidden">
+                    <span class="icon fa fa-spinner fa-spin" aria-hidden="true"></span>
+                    <span class="sr">${_('Loading')}</span>
+                  </div>
+                </div>
+              </button>
+            </form>
+          </div>
+          
+          <div id="filter-bar" class="filters hide-phone is-collapsed">
+          </div> 
+        -->
         % endif
 
         <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
@@ -68,11 +71,14 @@
 
 
         % if course_discovery_enabled:
-        <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
-          <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
-          <section class="search-facets-lists">
-          </section>
-        </aside>
+        <!--
+
+          <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
+            <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
+            <section class="search-facets-lists">
+            </section>
+          </aside>
+        -->
         % endif
 
       </section>

--- a/lms/templates/discovery/course_card.underscore
+++ b/lms/templates/discovery/course_card.underscore
@@ -8,16 +8,22 @@
         </header>
         <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
-                <span class="course-organization"><%- org %></span>
-                <span class="course-code"><%- content.number %></span>
+                <!--
+
+                    <span class="course-organization"><%- org %></span>
+                    <span class="course-code"><%- content.number %></span>
+                -->
                 <span class="course-title"><%- content.display_name %></span>
             </h2>
-            <div class="course-date" aria-hidden="true">
-                <%- interpolate(
-                      gettext("Starts: %(start_date)s"),
-                      { start_date: start }, true
-                    ) %>
-            </div>
+            <!--
+
+                <div class="course-date" aria-hidden="true">
+                    <%- interpolate(
+                        gettext("Starts: %(start_date)s"),
+                        { start_date: start }, true
+                        ) %>
+                    </div>
+                -->
         </section>
         <div class="sr">
             <ul>

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -27,7 +27,7 @@ enterprise_customer_link = get_enterprise_learner_portal(request)
         % endif
     </a>
   % else:
-    <a href="${branding_api.get_home_url()}">
+    <a href="/courses">
       <%block name="navigation_logo">
         <img  class="logo" src="${branding_api.get_logo_url(is_secure)}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
       </%block>


### PR DESCRIPTION
Description

- When clicked on site logo, redirect to /courses instead of home_url
- Hide search and filter_panel
- course_card in "explore courses" page only display course_image and course_name