### PR TITLE
fix: remove footer import in explore-course folder

### DIFF
--- a/lms/static/sass/funix/explore_course/_build.scss
+++ b/lms/static/sass/funix/explore_course/_build.scss
@@ -1,5 +1,4 @@
 @import "explore-course";
 @import "header";
 @import "course-list";
-@import "footer";
 @import 'search-input';


### PR DESCRIPTION
## Description

- Remove footer import in _build.scss file in explore-course folder