### PR TITLE
fix: comment course_org and course_code in template instead of using css

### DIFF
--- a/lms/static/sass/funix/explore_course/_course-list.scss
+++ b/lms/static/sass/funix/explore_course/_course-list.scss
@@ -66,15 +66,15 @@
                                         line-height: 150%; /* 27px */
                                     }
 
-                                    span.course-code,
-                                    span.course-organization {
-                                        display: none;
-                                    }
+                                    // span.course-code,
+                                    // span.course-organization {
+                                    //     display: none;
+                                    // }
                                 }
 
-                                div.course-date {
-                                    display: none;
-                                }
+                                // div.course-date {
+                                //     display: none;
+                                // }
                             }
                         }
                     }

--- a/lms/templates/discovery/course_card.underscore
+++ b/lms/templates/discovery/course_card.underscore
@@ -8,20 +8,22 @@
         </header>
         <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
-
+<!-- 
                     <span class="course-organization"><%- org %></span>
                     <span class="course-code"><%- content.number %></span>
+-->
         
                 <span class="course-title"><%- content.display_name %></span>
             </h2>
             
-
+<!-- 
                 <div class="course-date" aria-hidden="true">
                     <%- interpolate(
                         gettext("Starts: %(start_date)s"),
                         { start_date: start }, true
                         ) %>
                     </div>
+-->
             
         </section>
         <div class="sr">


### PR DESCRIPTION
## Description

- comment course_org and course_code in template instead of using css
